### PR TITLE
Add popup for displaying off-screen matches

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -49,6 +49,8 @@ function! matchup#matchparen#enable() " {{{1
     autocmd InsertLeave * call s:matchparen.highlight(1)
   augroup END
 
+  call s:init_match_popup()
+
   if has('vim_starting')
     " prevent this from autoloading during timer callback at startup
     if g:matchup_matchparen_deferred
@@ -136,9 +138,7 @@ function! s:matchparen.clear() abort dict " {{{1
     unlet! w:matchup_match_id_list
   endif
 
-  if exists('w:match_popup')
-    call popup_hide(w:match_popup)
-  endif
+  call popup_hide(s:match_popup)
   if exists('w:matchup_oldstatus')
     let &l:statusline = w:matchup_oldstatus
     unlet w:matchup_oldstatus
@@ -490,19 +490,6 @@ function s:matchparen.transmute_reset() abort dict
 endfunction
 
 " }}}1
-function! s:init_popup() abort " {{{1
-  if exists('w:match_popup')
-    " echoerr 'Match popup already exists in this window.'
-    return
-  endif
-  " Create a popup and store its winid
-  let w:match_popup = popup_create('', {
-        \ 'hidden': v:true,
-        \ })
-  call popup_hide(w:match_popup) " TODO 'hidden' in popup_create-usage unimplemented
-endfunction
-
-" }}}1
 function! s:do_offscreen(current) " {{{1
   let l:offscreen = {}
 
@@ -548,9 +535,17 @@ function! s:do_offscreen_statusline(offscreen) " {{{1
 endfunction
 
 " }}}1
-function! s:do_offscreen_popup(offscreen) " {{{1
-  call s:init_popup() " TODO Do in WinNew autocmd
+function! s:init_match_popup() abort " {{{1
+  call assert_false(exists('s:match_popup'), 'Popup already exists.')
+  " Create a popup and store its winid
+  let s:match_popup = popup_create('', {
+        \ 'hidden': v:true,
+        \ })
+  call popup_hide(s:match_popup) " TODO 'hidden' in popup_create-usage unimplemented
+endfunction
 
+" }}}1
+function! s:do_offscreen_popup(offscreen) " {{{1
   " Screen position of top-left corner of current window
   let [l:row, l:col] = win_screenpos(winnr())
   let l:col += (&number || &relativenumber ? &numberwidth : 0)
@@ -559,14 +554,14 @@ function! s:do_offscreen_popup(offscreen) " {{{1
   let l:line = a:offscreen.lnum < line('.') ? l:row : l:row + l:height - 1
   if l:line == winline() | return | endif " If popup would overlap with cursor
 
-  call popup_move(w:match_popup, {
+  call popup_move(s:match_popup, {
         \ 'line': line,
         \ 'col': col,
         \ 'maxheight': 1,
         \ })
   " Set popup text
-  call setbufline(winbufnr(w:match_popup), 1, getline(a:offscreen.lnum))
-  call popup_show(w:match_popup)
+  call setbufline(winbufnr(s:match_popup), 1, getline(a:offscreen.lnum))
+  call popup_show(s:match_popup)
 endfunction
 
 " }}}1


### PR DESCRIPTION
Implements a cool feature found in JetBrains IDE:s among others, where the line of the match is displayed in a popup, using the new [popup API](https://github.com/vim/vim/blob/db51730df1817fc4b6ecf5a065c69fac518ad821/runtime/doc/popup.txt) from Vim version 8.1. Currently it just replaces the status line feature, which is less than ideal. Could use some pointers on the best set of options to make it all configurable. Checks need to be added for availability of the popup feature. The implementation is also really rough, not to mention the popup API being unstable, but it works as a proof-of-concept.

## Screenshot
![matchup-popup-screenshot](https://user-images.githubusercontent.com/3679678/59717124-b3cd7380-9217-11e9-81ac-6927f3beefd4.gif)

The popup is displayed at the top of the window for matches above the view, and respectively at the bottom for matches below.

The fact that Vim does not have an autocommand for scrolling (issue vim/vim#776) is a complication, since eventual inconsistencies become much more apparent with a popup than if only the status line was left unchanged. Nothing too annoying, and could maybe be worked around by handling the `CursorHold` autocommand and hook the most common motions that move the cursor line.