### PR TITLE
Fix tab indent for popup

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -597,7 +597,14 @@ function! s:do_offscreen_popup(offscreen) " {{{1
   if &number || &relativenumber
     let l:text = printf('%*S ', wincol()-virtcol('.')-1, l:lnum)
   endif
-  let l:text .= getline(l:lnum) . ' '
+
+  " replace tab indent with spaces
+  " (popup window doesn't follow tabstop option of current buffer)
+  let l:linestr = getline(l:lnum)
+  let l:indent = repeat(' ', strdisplaywidth(matchstr(l:linestr, '^\s\+')))
+  let l:linestr = substitute(l:linestr, '^\s\+', l:indent, '')
+
+  let l:text .= l:linestr . ' '
   if l:adjust
     let l:text .= '… ' . a:offscreen.match . ' '
   endif


### PR DESCRIPTION
Thank you for the great plugin! I'm using your plugin with Vim 8.2 and its popup feature:

```vim
let g:matchup_matchparen_offscreen = {
  \   'method': 'popup',
  \ }
```

My environment:
- macOS 10.15.2
- Vim 8.2 (patch 1-319)

I prefer tab indent and sometimes popup window renders it as different width like this:

<img width="675" alt="master" src="https://user-images.githubusercontent.com/602961/79061660-6d2c9680-7ccd-11ea-8784-1299fa516463.png">

HTML file for reproducing the behavior (please try it with the option `:set tabstop=2`):
https://gist.github.com/cocopon/3de4fe7e43a5713ac473ae18688a10fd

I think Vim popup window maybe doesn't follow tabstop option of the current buffer. This pull request will fix the problem by replacing tab characters with spaces.

<img width="675" alt="fixed" src="https://user-images.githubusercontent.com/602961/79061666-71f14a80-7ccd-11ea-9734-ed16fc9d2e51.png">

Neovim floating window works fine so I fixed only the code for Vim popup window.