### PR TITLE
offscreen highlight doesn't work when cursorline is set

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -637,7 +637,14 @@ function! s:do_offscreen_popup_nvim(offscreen) " {{{1
 
     if has_key(g:matchup_matchparen_offscreen, 'highlight')
       call nvim_win_set_option(s:float_id, 'winhighlight',
-            \ 'Normal:' . g:matchup_matchparen_offscreen.highlight)
+            \ 'Normal:' . g:matchup_matchparen_offscreen.highlight .
+            \ ',LineNr:CursorLineNr')
+    else
+      call nvim_win_set_option(s:float_id, 'winhighlight', 'LineNr:CursorLineNr')
+    endif
+
+    if &cursorline
+      call nvim_win_set_option(s:float_id, 'cursorline', v:false)
     endif
 
     if &relativenumber


### PR DESCRIPTION
When `cursorline` is set, the left side is before the patched, right side is after the patched.
![image](https://user-images.githubusercontent.com/17562139/100111391-04370f00-2ea9-11eb-99dd-f797ace09b82.png)

I think `CursorLineNr` highlight for `LineNr` in floating window preview is more identifiable than raw `LineNr`. If you don't like it, I can remove my personal preference.