### PR TITLE
Honor `relativenumber` in popup

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -596,7 +596,12 @@ function! s:do_offscreen_popup(offscreen) " {{{1
   " set popup text
   let l:text = ''
   if &number || &relativenumber
-    let l:text = printf('%*S ', wincol()-virtcol('.')-1, l:lnum)
+    if &relativenumber
+      let l:displaynumber = abs(l:lnum - line('.'))
+    else
+      let l:displaynumber = l:lnum
+    endif
+    let l:text = printf('%*S ', wincol()-virtcol('.')-1, l:displaynumber)
   endif
 
   " replace tab indent with spaces


### PR DESCRIPTION
I think `relativenumber` is used by those who want to be able to prepend a count to <kbd>j</kbd> and <kbd>k</kbd>, at least this is true for me. As a consequence, typing numbers and quickly hitting <kbd>j</kbd>/<kbd>k</kbd> (instead of <kbd>g</kbd><kbd>g</kbd>) has got so much in my muscle memory (and likely in that of some of those people too) that the non-relative number of the popup line disorients me. Note that hitting <kbd>%</kbd>/<kbd>g</kbd><kbd>%</kbd> instead of N+<kbd>j</kbd>/<kbd>k</kbd> is not always an option, for instance in a long chain of `if`/`elseif`/`elseif`/.../`else`/`endif`.

Therefore, why not showing the line number in the offscreen popup honoring the option that the user uses? The change addresses this. Let me know if you like it.

If you're afraid some `rnu` user might be unhappy with this change (I don't think, personally, but still...), I can make an option such as `g:matchup_honor_rnu` set to `0` by default.