### PR TITLE
Ignore help tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Add `doc/tags` to `.gitignore` to suppress the "untracked content" message after running `:helptags` when this repository is a submodule.