### PR TITLE
tree-sitter: ignore matches in inner scopes

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -248,13 +248,14 @@ function M.get_matching(delim, down, bufnr)
           and (row >= info.search_range[1]
             and row <= info.search_range[3]) then
 
-        local scope = M.containing_scope(node, bufnr, info.key)
+        local target_scope = M.containing_scope(node, bufnr, info.key)
+        if info.scope == target_scope then
+          local text = ts_utils.get_node_text(node, bufnr)[1]
+          table.insert(matches, {text, row + 1, col + 1})
 
-        local text = ts_utils.get_node_text(node, bufnr)[1]
-        table.insert(matches, {text, row + 1, col + 1})
-
-        if side == 'close' then
-          got_close = true
+          if side == 'close' then
+            got_close = true
+          end
         end
       end
     end

--- a/test/vader/ts_py_motion.vader
+++ b/test/vader/ts_py_motion.vader
@@ -10,17 +10,24 @@ Execute (Helper):
   endif
 
 Given python (A python script):
-  def F(x):
+  def F(x, y):
     if x == 1:
       return 1
     elif x == 2:
-      pass
+      if y == 5:
+        pass
+      elif y == 7:
+        return 9
+      else:
+        return x
     else:
       return 3
     return 2
 
 Execute (Logs):
   Log b:matchup_active_engines
+
+# ----- outer if/elif/else -----
 
 Before (Cursor):
   normal! 2gg^
@@ -33,7 +40,7 @@ Then (Verify line):
 Do (Move % twice):
   %%
 Then (Verify line):
-  Assert line('.') == (TSActive() ? 6 : 2)
+  Assert line('.') == (TSActive() ? 11 : 2)
 
 Do (Move % 3 times):
   %%%
@@ -44,3 +51,28 @@ Do (Move % 4 times):
   %%%%
 Then (Verify line):
   Assert line('.') == (TSActive() ? 4 : 2)
+
+# ----- inner if/elif/else -----
+
+Before (Cursor):
+  normal! 5gg^
+
+Do (Inner: Move %):
+  %
+Then (Verify line):
+  Assert line('.') == (TSActive() ? 7 : 5)
+
+Do (Inner: % 2 times):
+  %%
+Then (Verify line):
+  Assert line('.') == (TSActive() ? 9 : 5)
+
+Do (Inner: % 3 times):
+  %%%
+Then (Verify line):
+  Assert line('.') == (TSActive() ? 5 : 5)
+
+Do (Inner: % 4 times):
+  %%%%
+Then (Verify line):
+  Assert line('.') == (TSActive() ? 7 : 5)


### PR DESCRIPTION
Previously, in the example below, placing the cursor on line 1 would highlight every elif and else in the whole block of code. % would jump to line 4, then % from there would cycle between lines 2, 4 and 6.

```
 1   if noice:
 2       if yeah:
 3           pass
 4       elif no:
 5           pass
 6       else:
 7           pass
 8   elif blah:
 9       pass
10   else:
11       pass
```


With the change, which I think the code had contemplated given there was already an unused `M.containing_scope(node, bufnr, info.key)` call, % will only move between ifs and elses that are in the same `@scope.if_`, and not to any inner scopes. Hence the example will have two mutually exclusive %-cycles: [1, 8, 10] and [2, 4, 6].