### PR TITLE
Add "unless" matchup for Ruby

### DIFF
--- a/after/queries/ruby/matchup.scm
+++ b/after/queries/ruby/matchup.scm
@@ -22,7 +22,6 @@
 (unless
   "unless" @open.unless
   "end" @close.unless) @scope.unless
-(else "else" @mid.unless.2)
 
 (while
     "while" @open.loop

--- a/after/queries/ruby/matchup.scm
+++ b/after/queries/ruby/matchup.scm
@@ -15,8 +15,9 @@
 
 (if
   "if" @open.if
+  (else "else" @mid.if.2)?
   "end" @close.if) @scope.if
-(else "else" @mid.if.2)
+(elsif (else "else" @mid.if.2))
 (elsif "elsif" @mid.if.1)
 
 (unless

--- a/after/queries/ruby/matchup.scm
+++ b/after/queries/ruby/matchup.scm
@@ -19,6 +19,11 @@
 (else "else" @mid.if.2)
 (elsif "elsif" @mid.if.1)
 
+(unless
+  "unless" @open.unless
+  "end" @close.unless) @scope.unless
+(else "else" @mid.unless.2)
+
 (while
     "while" @open.loop
   body: (do

--- a/after/queries/ruby/matchup.scm
+++ b/after/queries/ruby/matchup.scm
@@ -22,6 +22,7 @@
 
 (unless
   "unless" @open.unless
+  (else "else" @mid.unless.2)?
   "end" @close.unless) @scope.unless
 
 (while


### PR DESCRIPTION
# Brief
Ability to matchup `unless` for Ruby language.

# Before
![unless-before](https://user-images.githubusercontent.com/32784713/127193996-3b153a61-821c-4383-a087-10ff336f3ac9.gif)

# After
![unless-after](https://user-images.githubusercontent.com/32784713/127193729-2d1779c8-fecd-4dcc-8af1-6cb0124310ea.gif)