### PR TITLE
Support offscreen popup borders options for Neovim 0.5+

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -670,8 +670,11 @@ function! s:do_offscreen_popup_nvim(offscreen) " {{{1
           \ 'height': &previewheight,
           \ 'focusable': v:false,
           \}
-    if get(g:matchup_matchparen_offscreen, 'border', 0)
-      let l:win_cfg.border = ['', '═' ,'╗', '║', '╝', '═', '', '']
+    let l:border = get(g:matchup_matchparen_offscreen, 'border', 0)
+    if !empty(l:border)
+      let l:win_cfg.border = has('nvim-0.5')
+            \ && type(l:border) == v:t_string
+            \ ? l:border : ['', '═' ,'╗', '║', '╝', '═', '', '']
       if l:lnum >= line('.')
         let l:win_cfg.row -= min([2, l:row - winline() - 1])
       endif


### PR DESCRIPTION
This tiny PR adds support for the window border options added in Neovim 0.5, as described in `:help nvim_open_win()`, to the offscreen popup. I don't usually code in Vimscript, so let me know if there's anything you'd like me to change. Thanks! 