### PR TITLE
Update matchup.txt

### DIFF
--- a/doc/matchup.txt
+++ b/doc/matchup.txt
@@ -188,8 +188,8 @@ the corresponding default left-hand side will not be mapped.
    [%          |<plug>(matchup-[%)|                        nx     motion
    ]%          |<plug>(matchup-]%)|                        nx     motion
    z%          |<plug>(matchup-z%)|                        nx     motion
-   a%          |<plug>(matchup-%)|                         x      text_obj
-   i%          |<plug>(matchup-%)|                         x      text_obj
+   a%          |<plug>(matchup-a%)|                        x      text_obj
+   i%          |<plug>(matchup-i%)|                        x      text_obj
    ds%         |<plug>(matchup-ds%)|                       n      surround
    cs%         |<plug>(matchup-cs%)|                       n      surround
    (none)      |<plug>(matchup-hi-surround)|               n      matchparen


### PR DESCRIPTION
Fixing small typos in help file concerning `a%` and `i%` mappings