### PR TITLE
fix: correct floating window position in Neovim 0.6 nightly

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -742,7 +742,7 @@ function! s:do_offscreen_popup_nvim(offscreen) " {{{1
       let l:win_cfg.border = has('nvim-0.5')
             \ && type(l:border) == v:t_string
             \ ? l:border : ['', '═' ,'╗', '║', '╝', '═', '', '']
-      if l:lnum >= line('.')
+      if !has('nvim-0.6') && l:lnum >= line('.')
         let l:win_cfg.row -= min([2, l:row - winline() - 1])
       endif
     endif


### PR DESCRIPTION
Following https://github.com/neovim/neovim/pull/15832
It is no longer necessary to subtract border height from row.