### PR TITLE
Add option to change virt text markers

### DIFF
--- a/autoload/matchup.vim
+++ b/autoload/matchup.vim
@@ -41,6 +41,8 @@ function! s:init_options()
   call s:init_option('matchup_matchparen_nomode', '')
   call s:init_option('matchup_matchparen_hi_surround_always', 0)
   call s:init_option('matchup_matchparen_hi_background', 0)
+  call s:init_option('matchup_matchparen_start_sign', '▶')
+  call s:init_option('matchup_matchparen_end_sign', '◀')
 
   call s:init_option('matchup_matchparen_timeout',
         \ get(g:, 'matchparen_timeout', 300))

--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -1025,7 +1025,7 @@ function! matchup#matchparen#status_str(offscreen, ...) abort " {{{1
   if empty(a:offscreen.links.close.match)
     let l:hi = s:wordish(a:offscreen.links.open)
           \ ? 'MatchWord' : 'MatchParen'
-    let l:sl .= ' ◀ ' . '%#' . l:hi . '#'
+    let l:sl .= ' ' . g:matchup_matchparen_end_sign . ' %#' . l:hi . '#'
           \ . a:offscreen.links.open.match . '%#Normal#'
   endif
 
@@ -1090,7 +1090,8 @@ function! s:add_matches(corrlist, ...) " {{{1
             \ bufnr('%'), 'disable_virtual_text')
         call nvim_buf_set_extmark(0, s:ns_id,
               \ l:corr.lnum - 1, l:corr.cnum - 1, {
-              \   'virt_text': [['◀ ' . a:corrlist[0].match, l:group]],
+              \   'virt_text': [[g:matchup_matchparen_end_sign . ' ' .
+              \    a:corrlist[0].match, l:group]],
               \})
       else
         call nvim_buf_add_highlight(0, s:ns_id, l:group,

--- a/autoload/matchup/where.vim
+++ b/autoload/matchup/where.vim
@@ -106,7 +106,7 @@ endfunction
 
 function! s:arrow()
   if empty(g:matchup_where_separator)
-    return '▶'
+    return g:matchup_matchparen_start_sign
   endif
   return g:matchup_where_separator
 endfunction


### PR DESCRIPTION
I have issues with specific char that is used as a marker by default, so it would be nice to add the ability to change it.

Here is how it looks for me:
![image](https://user-images.githubusercontent.com/39714069/141710558-e327e9c7-deb0-45bf-a89b-d79c944a27f3.png)

And after adding this options, it looks like this:
let g:matchup_matchparen_start_sign = ''
let g:matchup_matchparen_end_sign = ''
![image](https://user-images.githubusercontent.com/39714069/141710617-15ae730a-53da-4a32-a5b1-bc4b8d34b3dd.png)


