### PR TITLE
Avoid goto logic in internal.lua

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -191,25 +191,21 @@ function M.get_delim(bufnr, opts)
     local smallest_len = 1e31
     local result_info = nil
     for _, side in ipairs(side_table[opts.side]) do
-      if side == 'mid' and vim.g.matchup_delim_nomids > 0 then
-        goto continue
-      end
-
-      for _, node in ipairs(active_nodes[side]) do
-        if ts_utils.is_in_node_range(node, cursor[1]-1, cursor[2]) then
-          local len = ts_utils.node_length(node)
-          if len < smallest_len then
-            smallest_len = len
-            result_info = {
-              node = node,
-              side = side,
-              key = symbols[_node_id(node)]
-            }
+      if not(side == 'mid' and vim.g.matchup_delim_nomids > 0) then
+        for _, node in ipairs(active_nodes[side]) do
+          if ts_utils.is_in_node_range(node, cursor[1]-1, cursor[2]) then
+            local len = ts_utils.node_length(node)
+            if len < smallest_len then
+              smallest_len = len
+              result_info = {
+                node = node,
+                side = side,
+                key = symbols[_node_id(node)]
+              }
+            end
           end
         end
       end
-
-      ::continue::
     end
 
     if result_info then


### PR DESCRIPTION
The `goto` keyword is introduced in a newer version of lua, running this
plugin with an older version of lua will produce an error:

```
Error detected while processing function matchup#loader#bufwinenter[4]..matchup#loader#init_buffer[5]..matchup#ts_engine#is_enabled[4]..<SNR>126_forward:
line    1:
E5108: Error executing lua vim.lua:63: ...local/share/nvim/plugins/vim-matchup/lua/treesitter-matchup/internal.lua:195: '=' expected near 'continue'
stack traceback:
        [C]: in function 'error'
        vim.lua:63: in function <vim.lua:57>
        [C]: in function 'require'
        [string "luaeval()"]:1: in main chunk
Error detected while processing function matchup#loader#bufwinenter[4]..matchup#loader#init_buffer[15]..matchup#ts_engine#is_hl_enabled[4]..<SNR>126_forward:
line    1:
E5108: Error executing lua vim.lua:63: ...local/share/nvim/plugins/vim-matchup/lua/treesitter-matchup/internal.lua:195: '=' expected near 'continue'
stack traceback:
        [C]: in function 'error'
        vim.lua:63: in function <vim.lua:57>
        [C]: in function 'require'
        [string "luaeval()"]:1: in main chunk
Error detected while processing function matchup#loader#init_buffer[5]..matchup#ts_engine#is_enabled[4]..<SNR>126_forward:
line    1:
E5108: Error executing lua vim.lua:63: ...local/share/nvim/plugins/vim-matchup/lua/treesitter-matchup/internal.lua:195: '=' expected near 'continue'
stack traceback:
        [C]: in function 'error'
        vim.lua:63: in function <vim.lua:57>
        [C]: in function 'require'
        [string "luaeval()"]:1: in main chunk
```

This commit removes the goto keyword to avoid such error. Has been
tested on debian testing.

Related: https://github.com/AaronJackson/vrn/issues/157