### PR TITLE
Fix _node_text

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -135,10 +135,7 @@ end
 
 local function _node_text(node, bufnr)
   local text = vim.treesitter.query.get_node_text(node, bufnr)
-  if type(text) == "table" then
-    text = text[1]
-  end
-  return text
+  return text:match("(%S+).*")
 end
 
 --- Fill in a match result based on a seed node


### PR DESCRIPTION
I misunderstood the new default API in `nvim`  when I wrote #216 . This fixes that.

This comment clarified what `vim.treesitter.query.get_node_text` was actually returning: https://github.com/nvim-treesitter/nvim-treesitter/pull/2801#issuecomment-1101555994