### PR TITLE
Fix javascript treesitter queries for function

### DIFF
--- a/after/queries/javascript/matchup.scm
+++ b/after/queries/javascript/matchup.scm
@@ -1,5 +1,10 @@
 ; functions
-(function_declaration "function" @open.function) @scope.function
+[
+  (arrow_function "=>" @open.function)
+  (function "function" @open.function)
+  (function_declaration "function" @open.function)
+] @scope.function
+
 (return_statement "return" @mid.function.1)
 
 ; switch case


### PR DESCRIPTION
Resolves: https://github.com/andymass/vim-matchup/issues/248

---

```js
function do_it() {
  const array = [1, 2, 3, 4];

  if (array.lenth > 5) {
    return 0;
  }

  const yyy = function () {
    return 1;
  };

  yy = function () {
    return 1;
  };

  const xxx = () => {
    return "xx";
  };

  xx = () => {
    return "xx";
  };

  for (const x of xs) {
    return 0;
  }

  array.forEach((x) => {
    if (x % 2 == 0) {
      xx();
      return;
    }
    console.log(x);
  });

  return 0;
}
```

![Peek 2022-09-19 20-02](https://user-images.githubusercontent.com/8050659/191035804-9157950b-caaf-47c4-ae16-592748b60755.gif)
