### PR TITLE
Pass bufnr to TS configs.is_enabled

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -21,13 +21,13 @@ local cache = lru.new(150)
 function M.is_enabled(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)
-  return configs.is_enabled('matchup', lang)
+  return configs.is_enabled('matchup', lang, bufnr)
 end
 
 function M.is_hl_enabled(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)
-  return configs.is_enabled('highlight', lang)
+  return configs.is_enabled('highlight', lang, bufnr)
 end
 
 function M.get_matches(bufnr)


### PR DESCRIPTION
This PR fixes calls to [is_enabled](https://github.com/nvim-treesitter/nvim-treesitter/blob/8ec59aee8097c64fcf27d1dbd77ea181c50846c5/lua/nvim-treesitter/configs.lua#L346) whcih requires `bufnr`. Currently user's custom [disable function](https://github.com/nvim-treesitter/nvim-treesitter/blob/8ec59aee8097c64fcf27d1dbd77ea181c50846c5/lua/nvim-treesitter/configs.lua#L364) doesn't receive proper arguments.