### PR TITLE
Fix `if let` expressions in Rust

### DIFF
--- a/after/queries/rust/matchup.scm
+++ b/after/queries/rust/matchup.scm
@@ -1,7 +1,7 @@
 ; --------------- if/else ---------------
 (block (if_expression "if" @open.if_) @scope.if_)
+(expression_statement (if_expression "if" @open.if_) @scope.if_)
 (let_declaration (if_expression "if" @open.if_) @scope.if_)
-(if_let_expression "if" @open.if_) @scope.if_
 
 (else_clause "else" @mid.if_.1 (block))
 (else_clause
@@ -22,7 +22,7 @@
 
 ; --------------- while/loop/for + break/continue ---------------
 (for_expression . "for" @open.loop) @scope.loop
-(while_let_expression . "while" @open.loop) @scope.loop
+(while_expression . "while" @open.loop) @scope.loop
 (loop_expression . "loop" @open.loop) @scope.loop
 
 (break_expression "break" @mid.loop.1 .)


### PR DESCRIPTION
After https://github.com/tree-sitter/tree-sitter-rust/commit/6ebdb1dc6cf4c19d8bae1d04f7bad44408e877d8 the node types `if_let_expression` and `while_let_expression` no longer exist but are merged into the normal `if_expression` and `while_expression`. This PR edits the Rust queries accordingly.

---

Side note: The `if_expression`s are only matched when their parent is either a `block`, `expression_statement` or `let_declaration`. Optimally we could just match `if_expression` with any parent except for `else_clause`.