### PR TITLE
fix(readme): `setup` is used to load options with `packer.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ it to your init.vim
 return require('packer').startup(function(use)
   use {
     'andymass/vim-matchup',
-    config = function()
+    setup = function()
       -- may set any options here
       vim.g.matchup_matchparen_offscreen = { method = "popup" }
     end
@@ -105,7 +105,7 @@ enabled as follows:
 ```lua
 {
   "andymass/vim-matchup",
-  config = function()
+  setup = function()
     vim.g.matchup_matchparen_offscreen = { method = "popup" }
   end,
 },


### PR DESCRIPTION
Hi! @andymass - This PR is just to recommend the correct parameter (`setup`) according to the `packer.nvim` documentation (see https://github.com/wbthomason/packer.nvim#specifying-plugins) and based on my experience for load options. For plugins built with VimScript, it is recommended to load options before the plugin loads, so that the plugin can detect them correctly, unlike plugins built entirely in Lua, which must be loaded before customization. Would you be so kind as to accept it ?? :)