### PR TITLE
fix typos in readme and doc about exclusive motion in visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ pressing `d]%` will produce (cursor on the `e`)
 if endif
 ```
 
-To include the close word, use either `dv]%` or `vd]%`.  This is also
+To include the close word, use either `dv]%` or `v]%d`.  This is also
 compatible with vim's `d])` and `d]}`.
 
 Operators over _backward_ exclusive motions will instead exclude the
@@ -416,7 +416,7 @@ example, pressing `d%` will leave behind nothing.
    )
 ```
 
-To operate character-wise in this situation, use `dv%` or `vd%`.
+To operate character-wise in this situation, use `dv%` or `v%d`.
 This is vim compatible with the built-in `d%` on `matchpairs`.
 
 ### Line-wise operator/text-object combinations

--- a/doc/matchup.txt
+++ b/doc/matchup.txt
@@ -347,7 +347,7 @@ pressing `d]%` will produce (cursor on the `e`) >
 
   if endif
 <
-To include the close word, use either `dv]%` or `vd]%`.  This is also
+To include the close word, use either `dv]%` or `v]%d`.  This is also
 compatible with vim's `dv])` and `dv]}`.
 
 Operators over backward exclusive motions will instead exclude the position
@@ -372,7 +372,7 @@ leave behind nothing. >
 
      )
 <
-To operate character-wise in this situation, use `dv%` or `vd%`.  This is vim
+To operate character-wise in this situation, use `dv%` or `v%d`.  This is vim
 compatible with the built-in `d%` on items in 'matchpairs'.
 
                                                         *matchup-feat-linewise*


### PR DESCRIPTION
Hi,
cool plugin! I had installed that for years, but only today I actually took the time to read through the whole documentation.
I stumbled upon two things that made me scratch my head for a minute, until I concluded they are just typos in the documentation. The diff should be self-explanatory.