### PR TITLE
Add ruby singleton class match

### DIFF
--- a/after/queries/ruby/matchup.scm
+++ b/after/queries/ruby/matchup.scm
@@ -12,6 +12,9 @@
 (class
   "class" @open.class
   "end" @close.class) @scope.class
+(singleton_class
+  "class" @open.class
+  "end" @close.class) @scope.class
 
 (if
   "if" @open.if


### PR DESCRIPTION
Now it'll match `singleton_class` like:

```ruby
class << self
  # ...
end
```