### PR TITLE
Update nvim 0.7 treesitter api (again)

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -204,7 +204,7 @@ function M.get_delim(bufnr, opts)
     for _, side in ipairs(side_table[opts.side]) do
       if not(side == 'mid' and vim.g.matchup_delim_nomids > 0) then
         for _, node in ipairs(active_nodes[side]) do
-          if ts_utils.is_in_node_range(node, cursor[1]-1, cursor[2]) then
+          if vim.treesitter.is_in_node_range(node, cursor[1]-1, cursor[2]) then
             local len = ts_utils.node_length(node)
             if len < smallest_len then
               smallest_len = len

--- a/lua/treesitter-matchup/third-party/hl-info.lua
+++ b/lua/treesitter-matchup/third-party/hl-info.lua
@@ -46,7 +46,7 @@ if vim.treesitter.highlighter.hl_map and vim.fn.has('nvim-0.9.0') == 0 then
       local iter = query:query():iter_captures(root, self.bufnr, row, row + 1)
 
       for capture, node, _ in iter do
-        if ts_utils.is_in_node_range(node, row, col) then
+        if vim.treesitter.is_in_node_range(node, row, col) then
           local c = query._query.captures[capture] -- name of the capture in the query
           if c ~= nil then
             local general_hl, is_vim_hl = query:_get_hl_from_capture(capture)

--- a/lua/treesitter-matchup/third-party/utils.lua
+++ b/lua/treesitter-matchup/third-party/utils.lua
@@ -67,7 +67,7 @@ function M.get_hl_groups_at_position(bufnr, row, col)
     for capture, node, metadata in iter do
       local hl = query.hl_cache[capture]
 
-      if hl and ts_utils.is_in_node_range(node, row, col) then
+      if hl and vim.treesitter.is_in_node_range(node, row, col) then
         local c = query._query.captures[capture] -- name of the capture in the query
         if c ~= nil then
           table.insert(matches, { capture = c, priority = metadata.priority })


### PR DESCRIPTION
As in #215, `nvim-treesitter` has deprecated `is_in_node_range` (nvim-treesitter/nvim-treesitter@2c2430d) in favor of `vim.treesitter.is_in_node_range`. This PR makes that change.