### PR TITLE
fix: Move to non-deprecated `vim.treesitter` function calls

### DIFF
--- a/lua/treesitter-matchup/compat.lua
+++ b/lua/treesitter-matchup/compat.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+local ts = vim.treesitter
+local tsq = vim.treesitter.query
+
+M.get_node_text = function(node, source, opts)
+    return (ts.get_node_text or tsq.get_node_text)(node, source, opts)
+end
+
+M.get_query = function(lang, query_name)
+    return (tsq.get or tsq.get_query)(lang, query_name)
+end
+
+return M

--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -5,7 +5,7 @@ end
 
 local vim = vim
 local api = vim.api
-local ts = vim.treesitter
+local ts = require'treesitter-matchup.compat'
 local configs = require'nvim-treesitter.configs'
 local parsers = require'nvim-treesitter.parsers'
 local queries = require'treesitter-matchup.third-party.query'
@@ -155,7 +155,7 @@ function M.containing_scope(node, bufnr, key)
 end
 
 local function _node_text(node, bufnr)
-  local text = ts.query.get_node_text(node, bufnr)
+  local text = ts.get_node_text(node, bufnr)
   return text:match("(%S+).*")
 end
 

--- a/lua/treesitter-matchup/third-party/query.lua
+++ b/lua/treesitter-matchup/third-party/query.lua
@@ -4,7 +4,7 @@
 -- See nvim-treesitter.LICENSE-APACHE-2.0
 
 local api = vim.api
-local tsq = require "vim.treesitter.query"
+local ts = require 'treesitter-matchup.compat'
 local tsrange = require "nvim-treesitter.tsrange"
 local utils = require "nvim-treesitter.utils"
 local parsers = require "nvim-treesitter.parsers"
@@ -52,7 +52,7 @@ do
   ---@param query_name string
   function M.get_query(lang, query_name)
     if cache[lang][query_name] == nil then
-      cache[lang][query_name] = tsq.get_query(lang, query_name)
+      cache[lang][query_name] = ts.get_query(lang, query_name)
     end
 
     return cache[lang][query_name]


### PR DESCRIPTION
ref: neovim/neovim@cbbf8bd
~~The new function calls are not yet on neovim stable, and have just been updated. I suggest to merge this after the release of `0.9.0`.~~
We could make a compatibility module [similar to nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/compat.lua) (the devs told me they shouldn't be used by 3rd party plugins, so we should make our own?).