### PR TITLE
Enable tagnameonly functionality for jsx files

### DIFF
--- a/after/ftplugin/javascriptreact_matchup.vim
+++ b/after/ftplugin/javascriptreact_matchup.vim
@@ -1,0 +1,25 @@
+" vim match-up - even better matching
+"
+" Maintainer: Andy Massimino
+" Email:      a@normed.space
+"
+
+if !exists('g:loaded_matchup') || !exists('b:did_ftplugin')
+  finish
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let b:match_skip = 's:\%(comment\|string\)\%(tsxCloseString\)\@<!'
+
+if matchup#util#matchpref('tagnameonly', 0)
+  call matchup#util#patch_match_words('\)\%(', '\)\g{hlend}\%(')
+  call matchup#util#patch_match_words('\)\%(', '\)\g{hlend}\%(')
+  call matchup#util#patch_match_words('1>', '1\g{hlend}>')
+  call matchup#util#patch_match_words(':/>', ':/\g{hlend}>')
+endif
+
+let &cpo = s:save_cpo
+
+" vim: sw=2

--- a/after/ftplugin/javascriptreact_matchup.vim
+++ b/after/ftplugin/javascriptreact_matchup.vim
@@ -11,7 +11,7 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-let b:match_skip = 's:\%(comment\|string\)\%(tsxCloseString\)\@<!'
+let b:match_skip = 's:\%(comment\|string\)\%(jsxCloseString\)\@<!'
 
 if matchup#util#matchpref('tagnameonly', 0)
   call matchup#util#patch_match_words('\)\%(', '\)\g{hlend}\%(')


### PR DESCRIPTION
Noticed enabling the `tagnameonly` preference worked for my `.tsx` files, but not for my `.jsx` ones. This change should fix it.