### PR TITLE
Added nix support

### DIFF
--- a/after/queries/nix/matchup.scm
+++ b/after/queries/nix/matchup.scm
@@ -1,0 +1,6 @@
+; --------------- let/in ---------------
+(let_expression "let" @open.let (binding_set)
+  "in" @mid.let.1 (_)) @scope.let
+; --------------- binding --------------
+; (binding (_)+ (function_exppression) ";") tend to be many lines lone
+(binding (attrpath) @open.binding (function_expression) ";" @close.binding) @scope.binding

--- a/after/queries/nix/matchup.scm
+++ b/after/queries/nix/matchup.scm
@@ -1,6 +1,9 @@
 ; --------------- let/in ---------------
-(let_expression "let" @open.let (binding_set)
+(let_expression
+  "let" @open.let (binding_set)
   "in" @mid.let.1 (_)) @scope.let
 ; --------------- binding --------------
-; (binding (_)+ (function_exppression) ";") tend to be many lines lone
-(binding (attrpath) @open.binding (function_expression) ";" @close.binding) @scope.binding
+; (binding (_)+ (function_exppression) ";") tend to be many lines long
+(binding
+  (attrpath) @open.binding (function_expression)
+  ";" @close.binding) @scope.binding


### PR DESCRIPTION
Implemented nix support:
* Added `let`/`in` matching:
![image](https://github.com/andymass/vim-matchup/assets/11223234/33245e7f-cb19-4859-a7c8-85f980da4ca6)
* Added jumping to end for `binding`s that hold a `function_expression`