### PR TITLE
Use jsx queries in javascriptreact

### DIFF
--- a/after/queries/javascriptreact/matchup.scm
+++ b/after/queries/javascriptreact/matchup.scm
@@ -1,0 +1,2 @@
+; inherits: ecma,jsx
+


### PR DESCRIPTION
For some time now jsx tags weren't matching in .jsx (javascriptreact) files when the treesitter integration is enabled.

Steps to reproduce:
1. Create `file.jsx` with the following contents
```jsx
import * as React from "react";
import * as ReactDOM from "react-dom";
ReactDOM.render(
	<div>
		<h1>Hello, Welcome to React and TypeScript</h1>
	</div>,
	document.getElementById("root")
);
```
2. Verify that `:echo &ft` outputs `javascriptreact`
3. Verify that treesitter integration is enabled
4. Put cursor on opening `<div>` tag.
5. Press `%` and cursor jumps to `)` just after `"root"` instead of the closing `</div>` tag.

I'm unsure why .tsx (typescriptreact) files work as expected and .jsx files do not, but this simple fix unifies the behaviour.