### PR TITLE
feat: add LaTeX3 matchup support.

### DIFF
--- a/after/ftplugin/tex_matchup.vim
+++ b/after/ftplugin/tex_matchup.vim
@@ -54,10 +54,31 @@ function! s:get_match_words()
   " latex equation markers
   let l:match_words .= ',\\(:\\),'.s:not_bslash.'\\\[:\\]'
 
+  " latex3 file i/o
+  let l:match_words .= ',\\ior_open\:NnT\?F\?\s*\\\([^\s]*\):\\ior_close\:N\s*\\\1'
+  let l:match_words .= ',\\ior_open\:cnT\?F\?\s*{\s*\([^\s\\}]*\)\s*}:\\ior_close\:c\s*{\s*\1\s*}'
+  let l:match_words .= ',\\iow_open\:Nn\s*\\\([^\s]*\):\\iow_close\:N\s*\\\1'
+  let l:match_words .= ',\\iow_open\:cn\s*{\s*\([^\s\\}]*\)\s*}:\\iow_close\:c\s*{\s*\1\s*}'
+
   " simple blocks
-  let l:match_words .= ',\\if\%(\w\|@\)*\>:\\else\>:\\fi\>'
+  let l:match_words .= ',\\if\%(\:w\|\%(\w\|@\)*\)\>:\\else\:*\>:\\fi\:*\>'
+  let l:match_words .= ',\\if_\%(true\|false\)\::\\else\::\\fi\:'
+  let l:match_words .= ',\\if_mode_\%(horizontal\|vertical\|math\|inner\)\::\\else\::\\fi\:'
+  let l:match_words .= ',\\if_\%(charcode\|catcode\|dim\)\:w:\\else\::\\fi\:'
+  let l:match_words .= ',\\if_cs_exist\:w:\\cs_end\::\\else\::\\fi\:'
+  let l:match_words .= ',\\if_cs_exist\:N:\\else\::\\fi\:'
+  let l:match_words .= ',\\if_[hv]box\:N:\\else\::\\fi\:'
+  let l:match_words .= ',\\if_box_empty\:N:\\else\::\\fi\:'
+  let l:match_words .= ',\\cs\:w:\\cs_end\:'
   let l:match_words .= ',\\makeatletter:\\makeatother'
+  let l:match_words .= ',\\ExplSyntaxOn:\\ExplSyntaxOff'
+  let l:match_words .= ',\\debug_suspend\::\\debug_resume\:'
   let l:match_words .= ',\\begingroup:\\endgroup,\\bgroup:\\egroup'
+  let l:match_words .= ',\\group_begin\::\\group_end\:'
+  let l:match_words .= ',\\group_align_safe_begin\::\\group_align_safe_end\:'
+  let l:match_words .= ',\\color_group_begin\::\\color_group_end\:'
+  let l:match_words .= ',\\cctab_begin\:[Nc]:\\cctab_end\:'
+  let l:match_words .= ',\\exp\:w:\\exp_end\(_continue_f\:n\?w\|\:\)'
 
   " environments
   let l:match_words .= ',\\begin{tabular}'

--- a/after/ftplugin/tex_matchup.vim
+++ b/after/ftplugin/tex_matchup.vim
@@ -61,7 +61,7 @@ function! s:get_match_words()
   let l:match_words .= ',\\iow_open\:cn\s*{\s*\([^\s\\}]*\)\s*}:\\iow_close\:c\s*{\s*\1\s*}'
 
   " simple blocks
-  let l:match_words .= ',\\if\%(\:w\|\%(\w\|@\)*\)\>:\\else\:*\>:\\fi\:*\>'
+  let l:match_words .= ',\\if\%(\:w\|\%(\w\|@\)*\)\>:\\else\:\?\>:\\fi\:\?\>'
   let l:match_words .= ',\\if_\%(true\|false\)\::\\else\::\\fi\:'
   let l:match_words .= ',\\if_mode_\%(horizontal\|vertical\|math\|inner\)\::\\else\::\\fi\:'
   let l:match_words .= ',\\if_\%(charcode\|catcode\|dim\)\:w:\\else\::\\fi\:'


### PR DESCRIPTION
Added matchup support for a bunch of LaTeX3 macros. (They are documented in `source3.pdf` and are the stable ones. In `l3candidates` I didn’t find any experimental macros which need matchup support anyway.)
![matchup-sc](https://github.com/andymass/vim-matchup/assets/86350742/10441783-b4f3-483f-b0ed-2ed82c757a56)

And here’s a test file which may be helpful: [`test-expl3-matchup.txt`](https://github.com/andymass/vim-matchup/files/12379580/test-expl3-matchup.txt) (maybe `:setf tex` is needed). And there’s something wrong with it: `\if_true|false:` has no signature `w`. (just aware of that

N.B., the only changed line is:
```vim
" let l:match_words .= ',\\if\%(\w\|@\)*\>:\\else\>:\\fi\>'
let l:match_words .= ',\\if\%(\:w\|\%(\w\|@\)*\)\>:\\else\:\?\>:\\fi\:\?\>'
```
since the LaTeX3 version (`\if:w\else:\fi:`) overlaps with the TeX version, and therefore the `\:` is placed before the `\>`. Thus a `set iskeyword+=\:` is needed for correct rendering. And that’s the reason why I didn’t use `\>` for the other `\else:\fi:`s.
Is it better for me to append `\>` after or not?