### PR TITLE
Add Rust closure || pairs

### DIFF
--- a/after/queries/rust/matchup.scm
+++ b/after/queries/rust/matchup.scm
@@ -18,9 +18,14 @@
 ; --------------- fn/return ---------------
 (function_item
   "fn" @open.function) @scope.function
-(closure_expression parameters: (closure_parameters . "|" @open.function "|" .) body: (block)) @scope.function
+(closure_expression) @scope.function
 (return_expression
   "return" @mid.function.1)
+
+; --------------- closures ---------------
+(closure_parameters
+  "|" @open.closureparams
+  "|" @close.closureparams) @scope.closureparams
 
 ; --------------- while/loop/for + break/continue ---------------
 (for_expression . "for" @open.loop) @scope.loop


### PR DESCRIPTION
Also remove `@open.function` from closure return. As far as I can tell, is currently broken. I couldn't figure out a way to have both closure open / return and || pairs.

If there's a better way to handle this, or if I'm missing something, happy to learn.

If closure return is more important than || pairs, also happy to close this pull request.