### PR TITLE
Fix ECMA method function return

### DIFF
--- a/after/queries/ecma/matchup.scm
+++ b/after/queries/ecma/matchup.scm
@@ -5,6 +5,7 @@
   (arrow_function "=>" @open.function)
   (function "function" @open.function)
   (function_declaration "function" @open.function)
+  (method_definition body: (statement_block "{" @open.function))
 ] @scope.function
 
 (return_statement "return" @mid.function.1)


### PR DESCRIPTION
Behavior before change:

![image](https://github.com/andymass/vim-matchup/assets/719605/757f5842-ac03-4e1f-9c76-17000d663cef)

Behavior after change:

![image](https://github.com/andymass/vim-matchup/assets/719605/9747f481-bf54-4a74-8a2b-eee3a1df784c)
