### PR TITLE
fix: go methods query missing

### DIFF
--- a/after/queries/go/matchup.scm
+++ b/after/queries/go/matchup.scm
@@ -1,4 +1,5 @@
 (function_declaration "func" @open.func) @scope.func
+(method_declaration "func" @open.func) @scope.func
 (func_literal "func" @open.func) @scope.func
 
 (return_statement "return" @mid.func.1)


### PR DESCRIPTION
https://go.dev/tour/methods/4
```
func (v *Vertex) Scale(f float64) {
	v.X = v.X * f
	v.Y = v.Y * f
}
```