### PR TITLE
Add fish queries

### DIFF
--- a/after/queries/fish/matchup.scm
+++ b/after/queries/fish/matchup.scm
@@ -1,0 +1,32 @@
+(if_statement
+  "if" @open.if
+  (else_if_clause ("else" "if") @mid.if.1)?
+  (else_clause "else" @mid.if.2)?
+  "end" @close.if
+  ) @scope.if
+
+(switch_statement
+  "switch" @open.switch
+  (case_clause "case" @mid.switch.1)?
+  "end" @close.switch
+  ) @scope.switch
+
+(for_statement
+  "for" @open.loop
+  "in" @mid.loop.1
+  "end" @close.loop) @scope.loop
+((break) @mid.loop.2)?
+((continue) @mid.loop.3)?
+
+(while_statement
+  "while" @open.loop
+  "end" @close.loop) @scope.loop
+
+(begin_statement
+  "begin" @open.block
+  "end" @close.block) @scope.block
+
+(function_definition
+  "function" @open.func
+  "end" @close.func) @scope.func
+(return "return" @mid.func.1)


### PR DESCRIPTION
One thing that I'm not sure about is the `else if` handling: This is parsed as `(else_if_clause "else" "if" ...)` with two separate keywords. The query correctly matches this, but matchup will only highlight the `else`, whereas it would be great if it could highlight the entire `"else" "if"` including the whitespace between. Can this be done?