### PR TITLE
fix(query): use explicitly the legacy behavior

### DIFF
--- a/lua/treesitter-matchup/third-party/query.lua
+++ b/lua/treesitter-matchup/third-party/query.lua
@@ -205,7 +205,7 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
     curr_obj[path[#path]] = value
   end
 
-  local matches = query:iter_matches(qnode, bufnr, start_row, end_row)
+  local matches = query:iter_matches(qnode, bufnr, start_row, end_row, { all = false })
 
   local function iterator()
     local pattern, match, metadata = matches()


### PR DESCRIPTION
After https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8 it is necessary to opt-in explicitly to the old behavior.

Fixes #360.