### PR TITLE
use texMathZoneTI for vimtex v2.11

### DIFF
--- a/after/ftplugin/tex_matchup.vim
+++ b/after/ftplugin/tex_matchup.vim
@@ -97,7 +97,11 @@ function! s:get_match_words()
   endif
 
   " dollar sign math
-  let l:match_words .= ',\$:\$\g{syn;!texMathZoneX}'
+  if exists('b:vimtex')
+    let l:match_words .= ',\$:\$\g{syn;!texMathZoneTI}'
+  else
+    let l:match_words .= ',\$:\$\g{syn;!texMathZoneX}'
+  endif
 
   return l:match_words
 endfunction


### PR DESCRIPTION
texMathZoneX was renamed to texMathZoneTI in
[vimtex 0cf45fd3f8128f427588098389634233738682f4](https://github.com/lervag/vimtex/commit/0cf45fd3f8128f427588098389634233738682f4)

Related: https://github.com/andymass/vim-matchup/issues/123

cc: @lervag 