### PR TITLE
Accept offscreen popup borders as lists

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -809,7 +809,7 @@ function! s:do_offscreen_popup_nvim(offscreen) abort " {{{1
     let l:border = get(g:matchup_matchparen_offscreen, 'border', 0)
     if !empty(l:border)
       let l:win_cfg.border = has('nvim-0.5')
-            \ && type(l:border) == v:t_string
+            \ && (type(l:border) == v:t_string || type(l:border) == v:t_list)
             \ ? l:border : ['', '═' ,'╗', '║', '╝', '═', '', '']
       if !has('nvim-0.6') && l:lnum >= line('.')
         let l:win_cfg.row -= min([2, l:row - winline() - 1])


### PR DESCRIPTION
Behaviour is in line with the current docs, i.e.: https://github.com/andymass/vim-matchup/blob/aca23ce53ebfe34e02c4fe07e29e9133a2026481/doc/matchup.txt#L698-L701