### PR TITLE
fix(queries/haskell): constructor/record -> record

### DIFF
--- a/after/queries/haskell/matchup.scm
+++ b/after/queries/haskell/matchup.scm
@@ -48,7 +48,7 @@
   "data" @open.rec (_)
   constructors: (data_constructors
     constructor: (data_constructor
-      (constructor/record
+      (record
         fields: (fields
           "{" @mid.rec.1 (_)
           "}" @mid.rec.2


### PR DESCRIPTION
Something appears to have changed, either in Neovim or in tree-sitter-haskell.
When opening a Haskell file, I'm greeted with a recurring error `impossible pattern: constructor/record`.

This seems to fix it.