### PR TITLE
Split treesitter matches at newlines instead of whitespace

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -163,7 +163,7 @@ end
 
 local function _node_text(node, bufnr)
   local text = ts.get_node_text(node, bufnr)
-  return text:match("(%S+).*")
+  return text:match("([^\n]+).*")
 end
 
 --- Fill in a match result based on a seed node


### PR DESCRIPTION
I believe this was the intention of the original change in (#217): there is some mixing of terminology in the review discussion, but I believe the intention was to extract the first line in the match, as suggested in the linked discussion, and not the string up to the first whitespace.