### PR TITLE
Disable winbar on neovim 0.8.0 and later

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -844,6 +844,10 @@ function! s:do_offscreen_popup_nvim(offscreen) abort " {{{1
     if &cursorline
       call nvim_win_set_option(s:float_id, 'cursorline', v:false)
     endif
+    " winbar was added in nvim 0.8.0
+    if has('nvim-0.8.0')
+      call nvim_win_set_option(s:float_id, 'winbar', '')
+    endif
 
     call s:populate_floating_win(a:offscreen, l:text_method)
 


### PR DESCRIPTION
I found a pretty obnoxious bug that can occur when a winbar is setup with the matchup floating windows where it can trigger `E36: Not enough room` error.

I've attached a video of the error occuring, and while I did try to solve it on the lualine side by conditionally disabling winbar in floating windows, I couldn't ever seem to get it to work. The only fix I found was just to wholesale disable winbar in these floating windows:

https://github.com/user-attachments/assets/2241d86d-3e55-42eb-8ca5-b65505b32fef

Unclear if this is the preferred way to do it, but I imagine a winbar shouldn't ever be shown in these scenarios regardless, so felt safe? Happy to change it to check for an option though if you'd prefer.
