### PR TITLE
fix(popup): clear popup window on nightly nvim >= 0.12

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -933,7 +933,8 @@ function! s:close_floating_win() " {{{1
   if !exists('s:float_id')
     return
   endif
-  if win_id2win(s:float_id) > 0
+  if (has('nvim-0.12') && s:float_id > 0) || (!has('nvim-0.12') && win_id2win(s:float_id) > 0)
+    echo "hello"
     call s:do_popup_autocmd_leave(s:float_id)
     call nvim_win_close(s:float_id, 0)
   endif

--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -934,7 +934,6 @@ function! s:close_floating_win() " {{{1
     return
   endif
   if (has('nvim-0.12') && s:float_id > 0) || (!has('nvim-0.12') && win_id2win(s:float_id) > 0)
-    echo "hello"
     call s:do_popup_autocmd_leave(s:float_id)
     call nvim_win_close(s:float_id, 0)
   endif


### PR DESCRIPTION
Fixes #391

Floating windows are not cleared. The reason is that `win_id2win()` returns 0 for some reason after some new changes in neovim.
Note that `nvim_open_win` returns a `window-ID`, and `nvim_win_close` needs a `window-ID` too. So in general, I don't know if `win_id2win` is necessary at all.