### PR TITLE
fix: silently fail nvim_buf_clear_namespace call in sandbox/modeline

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -140,7 +140,10 @@ function! s:matchparen.clear() abort dict " {{{1
     unlet! w:matchup_match_id_list
   endif
   if exists('s:ns_id')
-    call nvim_buf_clear_namespace(0, s:ns_id, 0, -1)
+    try
+      call nvim_buf_clear_namespace(0, s:ns_id, 0, -1)
+    catch /\<E12\>/
+    endtry
   endif
 
   if !has('nvim') && exists('t:match_popup') && (exists('*win_gettype')


### PR DESCRIPTION
Fixes #394 

This PR makes the line silently fail. I tried deferring it's execution, but it wasn't allowed either when in sandbox/modeline.

Another option would be to `throw` a new error, mentioning where the error is coming from (setting the value of `signcolumn` on a modeline). I guess a third option could be to rework the logic of the plugin to check if `signcolumn` is set each time it needs to, instead of relying on an autocmd of when it value changes. But, I don't know this side of the codebase (nor vimscript) enought to make such change.