### PR TITLE
fix: enable treesitter virtual text by default

### DIFF
--- a/autoload/matchup.vim
+++ b/autoload/matchup.vim
@@ -82,7 +82,7 @@ function! s:init_options()
     call s:init_option('matchup_treesitter_disabled', {})
     call s:init_option('matchup_treesitter_include_match_words', v:false)
     call s:init_option('matchup_treesitter_enable_quotes', v:true)
-    call s:init_option('matchup_treesitter_disable_virtual_text', v:true)
+    call s:init_option('matchup_treesitter_disable_virtual_text', v:false)
     call s:init_option('matchup_treesitter_stopline', 400)
   endif
 endfunction

--- a/autoload/matchup.vim
+++ b/autoload/matchup.vim
@@ -79,7 +79,7 @@ function! s:init_options()
 
   if has('nvim')
     call s:init_option('matchup_treesitter_enabled', has('nvim-0.11.2') ? v:true : v:false)
-    call s:init_option('matchup_treesitter_disabled', {})
+    call s:init_option('matchup_treesitter_disabled', [])
     call s:init_option('matchup_treesitter_include_match_words', v:false)
     call s:init_option('matchup_treesitter_enable_quotes', v:true)
     call s:init_option('matchup_treesitter_disable_virtual_text', v:false)


### PR DESCRIPTION
Should fix the issue described in https://github.com/andymass/vim-matchup/pull/390#issuecomment-3047043335