### PR TITLE
fix(haskell): use the correct captures for lambda case

### DIFF
--- a/after/queries/haskell/matchup.scm
+++ b/after/queries/haskell/matchup.scm
@@ -14,7 +14,8 @@
 
 ; --------------- lambda case ----------------
 (expression/lambda_case
-  "\\case" @open.case
+  "\\"
+  "case" @open.case
   (alternatives
     (alternative) @mid.case.1)) @scope.case
 


### PR DESCRIPTION
Fixes https://github.com/andymass/vim-matchup/commit/e4aae30b3f3401492c8cab262b2760ff230aa69e#commitcomment-161698373