### PR TITLE
fix: disable the matchup if no matchup queries were found

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -42,6 +42,10 @@ function M.is_enabled(bufnr)
   if err then
     return false
   end
+  local queries = ts.query.get_files(lang, "matchup")
+  if vim.tbl_isempty(queries) then
+    return false
+  end
   return is_enabled(lang, bufnr)
 end
 


### PR DESCRIPTION
Disable the matchup if no matchup queries were found, fallback to the `b:match_words` match.

Fix #398.