### PR TITLE
perf: use string.gmatch instead of vim.split

### DIFF
--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -111,7 +111,10 @@ local get_memoized_matches = memoize(function(bufnr, root, lang)
       local text = table.concat(lines, '\n')
 
       local name = query.captures[id]
-      local path = vim.split(name, '.', { plain = true })
+      local path = {} ---@type string[]
+      for part in name:gmatch('[^.]+') do
+        table.insert(path, part)
+      end
 
       local current = match_info ---@type table<string, table<string, matchup.treesitter.MatchInfo>>
       for _, segment in ipairs(path) do


### PR DESCRIPTION
For trees with a big number of injections (like, https://github.com/TheLeoP/mini.nvim/blob/90361abe531aaaad8b7ff04eac3d3a58d35668ad/tests/test_extra.lua#L2489 , specially, if you a are using [these injections](https://github.com/TheLeoP/nvim-config/blob/469923a07db70cb29fc25c51a11ad357f8ee5859/queries/lua/injections.scm#L3-L12)), `vim.split` can take 3 times as long as `parser:parse` to execute. Using `string.gmatch` directly avoids the performance issue