### PR TITLE
fix(go): update broken queries

### DIFF
--- a/after/queries/go/matchup.scm
+++ b/after/queries/go/matchup.scm
@@ -10,16 +10,12 @@
 (return_statement
   "return" @mid.func.1)
 
-; 'else' and 'else if'
+; 'if', 'else' and 'else if'
 (if_statement
+  "if" @open.if
   "else" @mid.if.1
   (if_statement
-    "if" @mid.if.1)?)
-
-; if
-(block
-  (if_statement
-    "if" @open.if) @scope.if)
+    "if" @mid.if.1)?) @scope.if
 
 ; switch
 (expression_switch_statement
@@ -27,7 +23,7 @@
   (expression_case
     "case" @mid.switch.1)
   (default_case
-    "default" @mid.switch.2)) @scope.switch
+    "default" @mid.switch.2)?) @scope.switch
 
 (_
   "\"" @open.quote_double


### PR DESCRIPTION
Current queries seem broken/outdated.

```
Error in function matchup#motion#find_matching_pair[31]..matchup#delim#get_current[1]..<SNR>51_get_delim_multi[3]..matchup#ts_engine#get_delim[3]..<SNR>45_forward:
line    1:
E5108: Lua: /home/phan/b/neovim/runtime/lua/vim/treesitter/query.lua:374: Query error at 21:3. Impossible pattern:
  (if_statement
  ^

stack traceback:
	[C]: in function '_ts_parse_query'
	/home/phan/b/neovim/runtime/lua/vim/treesitter/query.lua:374: in function 'fn'
	/home/phan/b/neovim/runtime/lua/vim/func/_memoize.lua:78: in function 'fn'
	/home/phan/b/neovim/runtime/lua/vim/func/_memoize.lua:78: in function 'get'
	...han/lazy/vim-matchup/lua/treesitter-matchup/internal.lua:82: in function 'fn'
	...-matchup/lua/treesitter-matchup/third-party/ts-utils.lua:19: in function 'get_memoized_matches'
	...han/lazy/vim-matchup/lua/treesitter-matchup/internal.lua:159: in function 'fn'
	...han/b/neovim/runtime/lua/vim/treesitter/languagetree.lua:666: in function 'for_each_tree'
	...han/lazy/vim-matchup/lua/treesitter-matchup/internal.lua:153: in function 'get_matches'
	...han/lazy/vim-matchup/lua/treesitter-matchup/internal.lua:210: in function 'get_active_matches'
	...han/lazy/vim-matchup/lua/treesitter-matchup/internal.lua:376: in function 'get_delim'
	[string "luaeval()"]:1: in main chunk
```
