### PR TITLE
fix(bash): highlight case delimiter only

### DIFF
--- a/after/queries/bash/matchup.scm
+++ b/after/queries/bash/matchup.scm
@@ -28,7 +28,7 @@
 
 (case_statement
   "case" @open.case
-  (case_item) @mid.case.1
+  (case_item (")" @mid.case.1))
   "esac" @close.case) @scope.case
 
 (heredoc_redirect


### PR DESCRIPTION
before
<img width="210" height="107" alt="Image" src="https://github.com/user-attachments/assets/2cd342db-78cc-496b-8a81-c773f46d4b4f" />

after
<img width="218" height="111" alt="Image" src="https://github.com/user-attachments/assets/9c572630-0280-4d25-92fe-a308df23e72e" />