### PR TITLE
Use pcall when calling get_node function

### DIFF
--- a/lua/treesitter-matchup/syntax.lua
+++ b/lua/treesitter-matchup/syntax.lua
@@ -40,8 +40,8 @@ function M.lang_skip(lnum, col)
     return false
   end
 
-  local node = vts.get_node({pos = {lnum - 1, col - 1}})
-  if not node then
+  local success, node = pcall(vts.get_node, {pos = {lnum - 1, col - 1}})
+  if not success or not node then
     return false
   end
   ---@diagnostic disable-next-line: missing-fields LuaLS bug


### PR DESCRIPTION
`vts.get_node` can raise an exception if an assert is failed. Since the 'lang_skip' function should just return a boolean, a failed assertion should be treated as a `false` return value.

I'm encountering this in ruby, where `assert(row >= 0 and col >= 0, 'Invalid position: row and col must be non-negative')` fails if I'm in visual-linewise-select mode and the cursor goes onto an empty line.

https://github.com/neovim/neovim/blob/master/runtime/lua/vim/treesitter.lua#L394-L426