### PR TITLE
fix(rust): correct type_parameters closing bracket capture

### DIFF
--- a/after/queries/rust/matchup.scm
+++ b/after/queries/rust/matchup.scm
@@ -7,7 +7,7 @@
 
 (type_parameters
   "<" @open.typeparams
-  ">" @open.typeparams) @scope.typeparams
+  ">" @close.typeparams) @scope.typeparams
 
 ; --------------- if/else ---------------
 (block


### PR DESCRIPTION
Fix typo in Rust tree-sitter query where `>` in type_parameters was captured as `@open.typeparams` instead of `@close.typeparams`

The current query doesn't capture angle brackets in trait definitions, such as:
```rust
pub trait SomeTrait<G> { }
```