### PR TITLE
feat: add blade matchup queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ more information. This plugin:
 - Extends vim's `%` motion to language-specific words. The following vim
   file type plugins currently provide special support for match-up:
 
-  > abaqus, ada, aspvbs, bash, c, cpp, chicken, clojure, cmake, cobol,
-  > context, csc, csh, dtd, dtrace, eiffel, eruby, falcon, fortran,
+  > abaqus, ada, aspvbs, bash, blade, c, cpp, chicken, clojure, cmake,
+  > cobol, context, csc, csh, dtd, dtrace, eiffel, eruby, falcon, fortran,
   > framescript, haml, hamster, hog, html, ishd, j, javascript,
   > javascriptreact, jsp, kconfig, liquid, lua, m3quake, make, matlab, mf,
   > modula2, modula3, mp, nsis, ocaml, pascal, pdf, perl, php, plaintex,

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ more information. This plugin:
 - Extends vim's `%` motion to language-specific words. The following vim
   file type plugins currently provide special support for match-up:
 
-  > abaqus, ada, aspvbs, bash, blade, c, cpp, chicken, clojure, cmake,
-  > cobol, context, csc, csh, dtd, dtrace, eiffel, eruby, falcon, fortran,
+  > abaqus, ada, aspvbs, bash, c, cpp, chicken, clojure, cmake, cobol,
+  > context, csc, csh, dtd, dtrace, eiffel, eruby, falcon, fortran,
   > framescript, haml, hamster, hog, html, ishd, j, javascript,
   > javascriptreact, jsp, kconfig, liquid, lua, m3quake, make, matlab, mf,
   > modula2, modula3, mp, nsis, ocaml, pascal, pdf, perl, php, plaintex,

--- a/after/queries/blade/matchup.scm
+++ b/after/queries/blade/matchup.scm
@@ -1,0 +1,17 @@
+; inherits: html
+
+[
+  (conditional)
+  (loop)
+  (switch)
+  (php_statement)
+  (once)
+  (stack)
+  (section)
+  (fragment)
+  (verbatim)
+] @scope.tag
+(
+  (directive_start) @open.tag
+  (directive_end) @close.tag
+)

--- a/after/queries/blade/matchup.scm
+++ b/after/queries/blade/matchup.scm
@@ -10,8 +10,8 @@
   (section)
   (fragment)
   (verbatim)
-] @scope.tag
+] @scope.directive
 (
-  (directive_start) @open.tag
-  (directive_end) @close.tag
+  (directive_start) @open.directive
+  (directive_end) @close.directive
 )


### PR DESCRIPTION
Just added Blade support. It inherits from HTML and matches most directives like sections, switches, loops, and custom stacks.