### PR TITLE
fix(bash): match case patterns instead of full branches

### DIFF
--- a/after/queries/bash/matchup.scm
+++ b/after/queries/bash/matchup.scm
@@ -28,7 +28,8 @@
 
 (case_statement
   "case" @open.case
-  (case_item) @mid.case.1
+  (case_item
+    value: (_) @mid.case.1)
   "esac" @close.case) @scope.case
 
 (heredoc_redirect


### PR DESCRIPTION
Tiny fix in the treesitter queries for bash: instead of matching full `case_item`s, which causes this:
<img width="2037" height="461" alt="image" src="https://github.com/user-attachments/assets/c09a2674-abe3-4ad1-b982-860f0bac82b9" />
we can match their named children `value`, resulting in this:
<img width="2039" height="466" alt="image" src="https://github.com/user-attachments/assets/c244aa50-1679-4c01-80fd-c0902f5b5b95" />
Note that `values` are separated by `or` (`|`), so this happens:
<img width="442" height="329" alt="image" src="https://github.com/user-attachments/assets/82a4d2a8-80f9-4226-ae65-8bd5cbdd29e5" />
(Note that the pipe character isn't highlighted; both matches are considered different).
