### PR TITLE
fix(treesitter): ctrl-c should interrupt `%`

### DIFF
--- a/autoload/matchup/delim.vim
+++ b/autoload/matchup/delim.vim
@@ -44,9 +44,8 @@ function! s:get_delim_multi(opts) abort " {{{1
   let l:best = {}
   for l:e in get(get(b:, 'matchup_active_engines', {}), a:opts.type, [])
     let l:res = call(s:engines[l:e].get_delim, [a:opts])
-    if empty(l:res)
-      continue
-    endif
+    if l:res is 0 | return | endif
+    if empty(l:res) | continue | endif
     if a:opts.direction ==# 'current'
       return l:res
     elseif a:opts.direction ==# 'next'

--- a/autoload/matchup/motion.vim
+++ b/autoload/matchup/motion.vim
@@ -53,6 +53,7 @@ function! matchup#motion#find_matching_pair(visual, down) " {{{1
 
   " get a delim where the cursor is
   let l:delim = matchup#delim#get_current('all', 'both_all')
+  if l:delim is 0 | return | endif
   if empty(l:delim)
     " otherwise search forward
     let l:delim = matchup#delim#get_next('all', 'both_all')

--- a/autoload/matchup/ts_engine.vim
+++ b/autoload/matchup/ts_engine.vim
@@ -25,6 +25,7 @@ function! matchup#ts_engine#get_delim(opts) abort
   call matchup#perf#tic('ts_engine.get_delim')
 
   let l:res = s:forward('get_delim', bufnr('%'), a:opts)
+  if l:res is 0 | return | endif
   if empty(l:res)
     call matchup#perf#toc('ts_engine.get_delim', 'fail')
     return {}

--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -71,8 +71,18 @@ local get_lang_matches = function(bufnr, root, lang, srow, erow)
     return {}
   end
 
+  local last_time = vim.uv.hrtime()
+  local check_interrupt = function()
+    if vim.uv.hrtime() - last_time > 100e6 then
+      local got_int = select(2, vim.wait(1)) == -2
+      if got_int then error('Interrupted') end
+      last_time = vim.uv.hrtime()
+    end
+  end
+
   local out = {} ---@type matchup.treesitter.Match[]
   for _, match, metadata in query:iter_matches(root, bufnr, srow, erow) do
+    check_interrupt()
     for id, nodes in pairs(match) do
       local first = nodes[1]
       local last = nodes[#nodes]

--- a/lua/treesitter-matchup/internal.lua
+++ b/lua/treesitter-matchup/internal.lua
@@ -74,7 +74,7 @@ local get_lang_matches = function(bufnr, root, lang, srow, erow)
   local last_time = vim.uv.hrtime()
   local check_interrupt = function()
     if vim.uv.hrtime() - last_time > 100e6 then
-      local got_int = select(2, vim.wait(1)) == -2
+      local got_int = select(2, vim.wait(0)) == -2
       if got_int then error('Interrupted') end
       last_time = vim.uv.hrtime()
     end


### PR DESCRIPTION
nvim often hang on `%` on file with slow treesitter support
