### PR TITLE
feat: add zsh matchup queries

### DIFF
--- a/after/queries/zsh/matchup.scm
+++ b/after/queries/zsh/matchup.scm
@@ -1,0 +1,1 @@
+; inherits: bash


### PR DESCRIPTION
The `bash` queries work perfectly fine with the `zsh` tree-sitter parser thanks to the similarity of both languages, so I think it would be nice to add Zsh support for the plugin by simply inheriting the `bash` queries for `zsh`.