### PR TITLE
fix(popup): don't close an already-closed offscreen float

### DIFF
--- a/autoload/matchup/matchparen.vim
+++ b/autoload/matchup/matchparen.vim
@@ -940,7 +940,8 @@ function! s:close_floating_win() " {{{1
   if !exists('s:float_id')
     return
   endif
-  if (has('nvim-0.12') && s:float_id > 0) || (!has('nvim-0.12') && win_id2win(s:float_id) > 0)
+  if (has('nvim-0.12') && s:float_id > 0 && nvim_win_is_valid(s:float_id))
+        \ || (!has('nvim-0.12') && win_id2win(s:float_id) > 0)
     call s:do_popup_autocmd_leave(s:float_id)
     call nvim_win_close(s:float_id, 0)
   endif


### PR DESCRIPTION
s:close_floating_win() on nvim >= 0.12 checks only that s:float_id is
non-zero before calling nvim_win_close(), so it throws E5555 "Invalid
window id" whenever the float was already destroyed by something else
(ex. a picker teardown, a q-to-close mapping, :only). s:float_id is
reset only inside this function, so the stale id survives and every
subsequent WinLeave/BufLeave raises the error:

    Error in BufLeave Autocommands ... close_floating_win

Guard with nvim_win_is_valid(), which is the right predicate here.
win_id2win() cannot be used on 0.12+: it is tabpage-scoped and returns 0
for a float owned by another tabpage, which is what #391 was about and
what 4f03d43 (#392) worked around by dropping the existence check
entirely. nvim_win_is_valid() tests existence without that scoping, so
this keeps #392 fixed while restoring the check it removed.

Verified on 0.12.4:

    float open, same tab   win_id2win=2  nvim_win_is_valid=v:true
    float open, other tab  win_id2win=0  nvim_win_is_valid=v:true
    float closed           win_id2win=0  nvim_win_is_valid=v:false

and, with a stale id, the current guard raises E5555 where the new one
correctly skips the close.
